### PR TITLE
Fix NoSuchMessageException from bad publication ID

### DIFF
--- a/src/org/labkey/trialshare/TrialShareController.java
+++ b/src/org/labkey/trialshare/TrialShareController.java
@@ -1248,7 +1248,7 @@ public class TrialShareController extends SpringActionController
                 }
                 catch (NumberFormatException ignore)
                 {
-                    errors.reject("Invalid publication id: " + form.getId());
+                    errors.reject(ERROR_MSG, "Invalid publication id: " + form.getId());
                 }
             }
         }


### PR DESCRIPTION
I don't think I was using `errors.reject` properly in my previous, related, fix: https://github.com/LabKey/trialShare/commit/f02522149cfb3a5b14d08c2f3a210ff5357598fd
I hope this will fix this crawler failure:
```
Current URL: /labkey/ManagePublicationsTestData%20Project/trialshare-insertDataForm.view?id=--%3E%22%3E%27%3E%27%22%3C%2Fscript%3E%3Cimg%20src%3D%22xss%22%20onerror%3D%22alert%28%228%28%22%29%3E&schemaName=lists&query.queryName=ManuscriptsAndAbstracts&query.viewName=manageData&returnUrl=%2Flabkey%2FManagePublicationTest%2520Project%2Ftrialshare-manageData.view%3FobjectName%3Dpublication%26query.viewName%3DmanageData&objectName=publication&domainURI=urn%3Alsid%3Alabkey.com%3AExtensibleTable-core.Folder-3%3AUsers&transformRunId=72&peptideProphetProbability=&listId=41
Current user: teamcity@labkey.test
ERROR ErrorsTag                2019-07-18 05:18:09,420     http-nio-8111-exec-5 : Failed to find a message: Error in object 'form': codes [Invalid publication id: -->">'>'"</script><img src="xss" onerror="alert("8(")>.form,Invalid publication id: -->">'>'"</script><img src="xss" onerror="alert("8(")>]; arguments []; default message [null]
org.springframework.context.NoSuchMessageException: No message found under code 'Invalid publication id: -->">'>'"</script><img src="xss" onerror="alert("8(")>' for locale 'en_US'.
	at org.springframework.context.support.AbstractMessageSource.getMessage(AbstractMessageSource.java:177)
	at org.labkey.api.view.ViewContext.getMessage(ViewContext.java:430)
	at org.labkey.api.jsp.taglib.ErrorsTag.doStartTag(ErrorsTag.java:72)
```