### PR TITLE
Make sure we don't try to create users that already exist

### DIFF
--- a/test/src/org/labkey/test/tests/trialshare/DataFinderTestBase.java
+++ b/test/src/org/labkey/test/tests/trialshare/DataFinderTestBase.java
@@ -126,6 +126,7 @@ public abstract class DataFinderTestBase extends BaseWebDriverTest
     {
         _containerHelper.deleteProject(getProjectName(), afterTest);
         _containerHelper.deleteProject(getDataProjectName(), afterTest);
+        _userHelper.deleteUsers(false, PUBLIC_READER, CASALE_READER, WISPR_READER);
     }
 
     @BeforeClass


### PR DESCRIPTION
Should fix TrialShare errors from my recent change to `APIUserHelper`