### PR TITLE
bound containerfilter

### DIFF
--- a/src/org/labkey/trialshare/data/StudyBean.java
+++ b/src/org/labkey/trialshare/data/StudyBean.java
@@ -303,7 +303,7 @@ public class StudyBean
             TableInfo sp = s.getTable("StudyProperties");
             if (sp.supportsContainerFilter())
             {
-                ContainerFilter cf = new ContainerFilter.AllInProject(user);
+                ContainerFilter cf = ContainerFilter.Type.AllInProject.create(s);
                 ((ContainerFilterable) sp).setContainerFilter(cf);
             }
             return new TableSelector(sp).getMapCollection();


### PR DESCRIPTION
#### Rationale
ContainerFilter is associated with a container at construction time.
Tables are constructed in the context of a specific container/user, the CF should also be specified and fixed at construction time as well.
