### PR TITLE
Add missing module dependencies and move dependencies declarations out of module.properties files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,3 @@
+import org.labkey.gradle.util.BuildUtils
+
+BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "study"), depProjectConfig: "published", depExtension: "module")

--- a/module.properties
+++ b/module.properties
@@ -4,4 +4,3 @@ Description: Provides a web part for exploring the studies and manuscripts avail
 URL: https://www.itntrialshare.org
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
-ModuleDependencies: Study


### PR DESCRIPTION
#### Rationale
We have deprecated the declaration of module dependencies in the `module.properties` file in favor of declaration in the `build.gradle` file.

#### Changes
* Move module dependency declarations from `module.properties` files to `build.gradle` files
