### PR TITLE
exclude Notebooks from the trial share export test

### DIFF
--- a/src/org/labkey/trialshare/TrialShareController.java
+++ b/src/org/labkey/trialshare/TrialShareController.java
@@ -32,7 +32,6 @@ import org.labkey.api.admin.FolderWriter;
 import org.labkey.api.admin.FolderWriterImpl;
 import org.labkey.api.admin.StaticLoggerGetter;
 import org.labkey.api.data.Container;
-import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.PHI;
 import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineService;

--- a/src/org/labkey/trialshare/TrialShareController.java
+++ b/src/org/labkey/trialshare/TrialShareController.java
@@ -32,6 +32,7 @@ import org.labkey.api.admin.FolderWriter;
 import org.labkey.api.admin.FolderWriterImpl;
 import org.labkey.api.admin.StaticLoggerGetter;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.PHI;
 import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineService;
@@ -571,7 +572,9 @@ public class TrialShareController extends SpringActionController
 
     public static class TrialShareExportTest
     {
-        private final Collection<FolderWriter> folderWriters = FolderSerializationRegistry.get().getRegisteredFolderWriters();
+        private final Collection<FolderWriter> folderWriters = FolderSerializationRegistry.get().getRegisteredFolderWriters().stream()
+                .filter(fw -> !"Notebooks".equals(fw.getDataType()))
+                .collect(Collectors.toList());
 
         @Test
         public void testDataTypes()


### PR DESCRIPTION
#### Rationale
The recent introduction of a new Notebook folder writer is causing [this failure](https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_GitPostgres/1172523?buildTab=tests&name=TrialShare&pager.currentPage=1) on Team City. Since Notebooks are currently not importable, it doesn't make sense to include them in the trial share export.

#### Changes
- Filter out Notebooks from the registered folder writers, Notebooks are not exposed through the UI by default but this test queries the folder writer registry directly.
