### PR TITLE
add sample types to expected export types

### DIFF
--- a/src/org/labkey/trialshare/TrialShareController.java
+++ b/src/org/labkey/trialshare/TrialShareController.java
@@ -113,6 +113,7 @@ public class TrialShareController extends SpringActionController
         private boolean externalSchemaDefinitions;
         private boolean wikisAndTheirAttachments;
         private boolean notificationSettings;
+        private boolean sampleTypes;
 
         public boolean getMissingValueIndicators()
         {
@@ -413,6 +414,16 @@ public class TrialShareController extends SpringActionController
         {
             this.notificationSettings = notificationSettings;
         }
+
+        public boolean getSampleTypes()
+        {
+            return sampleTypes;
+        }
+
+        public void setSampleTypes(boolean sampleTypes)
+        {
+            this.sampleTypes = sampleTypes;
+        }
     }
 
     /*
@@ -513,7 +524,8 @@ public class TrialShareController extends SpringActionController
                 FolderDataTypes.etlDefinitions,
                 FolderDataTypes.lists,
                 FolderDataTypes.wikisAndAttachments,
-                FolderDataTypes.notificationSettings);
+                FolderDataTypes.notificationSettings,
+                FolderDataTypes.sampleTypes);
     }
 
     enum FolderDataTypes
@@ -547,7 +559,8 @@ public class TrialShareController extends SpringActionController
         reportsAndCharts("Reports and Charts", TrialShareExportForm::getReportsAndCharts),
         externalSchemaDefinitions("External schema definitions", TrialShareExportForm::getExternalSchemaDefinitions),
         wikisAndAttachments("Wikis and their attachments", TrialShareExportForm::getWikisAndTheirAttachments),
-        notificationSettings("Notification settings", TrialShareExportForm::getNotificationSettings);
+        notificationSettings("Notification settings", TrialShareExportForm::getNotificationSettings),
+        sampleTypes("Sample Types", TrialShareExportForm::getSampleTypes);
 
         private final String _description;
         private final Function<TrialShareExportForm, Boolean> _formChecker;

--- a/test/src/org/labkey/test/tests/trialshare/TrialShareExportTest.java
+++ b/test/src/org/labkey/test/tests/trialshare/TrialShareExportTest.java
@@ -46,7 +46,7 @@ public class TrialShareExportTest extends BaseWebDriverTest
         goToModule("FileContent");
         _fileBrowserHelper.selectFileBrowserItem("/export/folder.xml");
         List<String> fileList = _fileBrowserHelper.getFileList();
-        List<String> expectedFiles = Arrays.asList("etls", "wikis", "folder.xml", "pages.xml");
+        List<String> expectedFiles = Arrays.asList("etls", "sample-types", "wikis", "folder.xml", "pages.xml");
         assertEquals("Default export should include several folder objects", expectedFiles, fileList);
     }
 


### PR DESCRIPTION
#### Rationale
The trial share module maintains it's own custom action to generate a folder archive. To keep this working we need to make the new sample type option available to the controller as well as specify it as a standard default type.