### PR TITLE
TrialShareController.TrialShareExportTest fix to add "Inventory locations and items"

### DIFF
--- a/src/org/labkey/trialshare/TrialShareController.java
+++ b/src/org/labkey/trialshare/TrialShareController.java
@@ -114,6 +114,7 @@ public class TrialShareController extends SpringActionController
         private boolean wikisAndTheirAttachments;
         private boolean notificationSettings;
         private boolean sampleTypesAndDataClasses;
+        private boolean inventoryLocationsAndItems;
 
         public boolean getMissingValueIndicators()
         {
@@ -424,6 +425,16 @@ public class TrialShareController extends SpringActionController
         {
             this.sampleTypesAndDataClasses = sampleTypesAndDataClasses;
         }
+
+        public boolean getInventoryLocationsAndItems()
+        {
+            return inventoryLocationsAndItems;
+        }
+
+        public void setInventoryLocationsAndItems(boolean inventoryLocationsAndItems)
+        {
+            this.inventoryLocationsAndItems = inventoryLocationsAndItems;
+        }
     }
 
     /*
@@ -525,7 +536,9 @@ public class TrialShareController extends SpringActionController
                 FolderDataTypes.lists,
                 FolderDataTypes.wikisAndAttachments,
                 FolderDataTypes.notificationSettings,
-                FolderDataTypes.sampleTypesAndDataClasses);
+                FolderDataTypes.sampleTypesAndDataClasses,
+                FolderDataTypes.inventoryLocationsAndItems
+        );
     }
 
     enum FolderDataTypes
@@ -560,7 +573,8 @@ public class TrialShareController extends SpringActionController
         externalSchemaDefinitions("External schema definitions", TrialShareExportForm::getExternalSchemaDefinitions),
         wikisAndAttachments("Wikis and their attachments", TrialShareExportForm::getWikisAndTheirAttachments),
         notificationSettings("Notification settings", TrialShareExportForm::getNotificationSettings),
-        sampleTypesAndDataClasses("Sample Types and Data Classes", TrialShareExportForm::getSampleTypesAndDataClasses);
+        sampleTypesAndDataClasses("Sample Types and Data Classes", TrialShareExportForm::getSampleTypesAndDataClasses),
+        inventoryLocationsAndItems("Inventory locations and items", TrialShareExportForm::getInventoryLocationsAndItems);
 
         private final String _description;
         private final Function<TrialShareExportForm, Boolean> _formChecker;

--- a/test/src/org/labkey/test/tests/trialshare/TrialShareExportTest.java
+++ b/test/src/org/labkey/test/tests/trialshare/TrialShareExportTest.java
@@ -46,7 +46,7 @@ public class TrialShareExportTest extends BaseWebDriverTest
         goToModule("FileContent");
         _fileBrowserHelper.selectFileBrowserItem("/export/folder.xml");
         List<String> fileList = _fileBrowserHelper.getFileList();
-        List<String> expectedFiles = Arrays.asList("etls", "sample-types", "wikis", "folder.xml", "pages.xml");
+        List<String> expectedFiles = Arrays.asList("etls", "inventory", "sample-types", "wikis", "folder.xml", "pages.xml");
         assertEquals("Default export should include several folder objects", expectedFiles, fileList);
     }
 


### PR DESCRIPTION
#### Rationale
TeamCity found a usages of a test that wants to know about all of the folder export options. This PR adds the new "Inventory locations and items" option to the list.

#### Changes
* TrialShareController.TrialShareExportTest fix to add "Inventory locations and items"
* TrialShareExportTest.testTrialShareExportActionDefault fix to add "inventory" to expected archive dir list