### PR TITLE
Use correct URL-generating method

### DIFF
--- a/src/org/labkey/trialshare/ITNSpecimenRequestCustomizer.java
+++ b/src/org/labkey/trialshare/ITNSpecimenRequestCustomizer.java
@@ -55,7 +55,7 @@ public class ITNSpecimenRequestCustomizer implements SpecimenService.SpecimenReq
         SpecimenUrls specimenUrls = PageFlowUtil.urlProvider(SpecimenUrls.class);
         return HtmlString.unsafe("Thank you for your request. A representative from the ITN will be in touch " +
                 "with you. You can also contact us at " +
-                link("trialsharesupport@immunetolerance.org").href("mailto:trialsharesupport@immunetolerance.org?Body=" + PageFlowUtil.filter(specimenUrls.getRequestDetailsURL(c, requestId).getURIString())).clearClasses() +
+                link("trialsharesupport@immunetolerance.org").href("mailto:trialsharesupport@immunetolerance.org?Body=" + PageFlowUtil.filter(specimenUrls.getManageRequestURL(c, requestId).getURIString())).clearClasses() +
                 " to follow up with us regarding this request.<br/>" +
                 "You may also update this request at any calendar to add comments or supporting " +
                 "documents by clicking here " + link("Update Request").href(specimenUrls.getManageRequestStatusURL(c, requestId)));


### PR DESCRIPTION
#### Rationale
`SpecimenUrls` clean up eliminated a duplicate "manage request" method

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2434
