### PR TITLE
Add PanoramaQC to expected list of export options

### DIFF
--- a/src/org/labkey/trialshare/TrialShareController.java
+++ b/src/org/labkey/trialshare/TrialShareController.java
@@ -447,7 +447,6 @@ public class TrialShareController extends SpringActionController
         {
             this.experimentsAndRuns = experimentsAndRuns;
         }
-
     }
 
     /*
@@ -659,7 +658,9 @@ public class TrialShareController extends SpringActionController
             Collections.sort(expectedDataTypes);
             Collections.sort(actualDefaultDataTypes);
 
-            Assert.assertEquals("TrialShareExport default data types do not match core defaults", expectedDataTypes, actualDefaultDataTypes);
+            expectedDataTypes.removeAll(actualDefaultDataTypes);
+
+            Assert.assertTrue("TrialShareExport default data types missing expected values: " + expectedDataTypes, expectedDataTypes.isEmpty());
         }
 
         public Set<String> getRegisteredDataTypes(boolean onlyDefault)


### PR DESCRIPTION
#### Rationale
I fixed the TrialShare export tests in develop (where it's now passing) but the failure started in 22.3.

#### Changes
* Backport fix to 22.3 branch.