### PR TITLE
Mark modules that support both databases

### DIFF
--- a/module.properties
+++ b/module.properties
@@ -4,3 +4,4 @@ Description: Overrides some behavior of the specimen module and provides Data Fi
 URL: https://www.itntrialshare.org
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql


### PR DESCRIPTION
#### Rationale
Need to explicitly declare support for SQL Server since we're about to change the default to PostgreSQL-only